### PR TITLE
reduce usage of any

### DIFF
--- a/src/core/containers.ts
+++ b/src/core/containers.ts
@@ -44,5 +44,5 @@ export interface ContainerSpec {
    * A map of key/value pairs that specify environment variables to be set
    * within the OCI container
    */
-  environment?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  environment?: { [key: string]: string }
 }

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -47,7 +47,7 @@ export interface Event {
    * subscription from all push events emitted by the GitHub gateway to just
    * those having originated from a specific repository.
    */
-  labels?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  labels?: { [key: string]: string }
   /**
    * An optional, succinct title for the Event, ideal for use in lists or in
    * scenarios where UI real estate is constrained.

--- a/src/core/jobs.ts
+++ b/src/core/jobs.ts
@@ -85,7 +85,7 @@ export interface JobSpec {
    * of tests until a database is launched and READY in a sidecar container),
    * then logic within those containers must account for these constraints.
    */
-  sidecarContainers?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  sidecarContainers?: { [key: string]: JobContainerSpec }
   /**
    * Specifies the time, in seconds, that must elapse before a running Job
    * should be considered to have timed out
@@ -156,7 +156,7 @@ export interface JobHost {
    * This provides an opaque mechanism for communicating Job needs such as
    * specific hardware like an SSD or GPU.
    */
-	nodeSelector?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+	nodeSelector?: { [key: string]: string }
 }
 
 /**

--- a/src/core/projects.ts
+++ b/src/core/projects.ts
@@ -96,7 +96,7 @@ export interface EventSubscription {
    * forgotten to apply applicable labels accidentally subscribes to ALL events
    * from the GitHub gateway, regardless of the repository of origin.
    */
-  labels: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  labels: { [key: string]: string }
 }
 
 /**

--- a/src/core/workers.ts
+++ b/src/core/workers.ts
@@ -1,7 +1,7 @@
 import * as rm from "../rest_machinery"
 
 import { ContainerSpec } from "./containers" 
-import { JobsClient } from "./jobs"
+import { Job, JobsClient } from "./jobs"
 
 /**
  * Represents the desired granularity of Worker log output.
@@ -136,7 +136,7 @@ export interface Worker {
    * Contains details of all Jobs spawned by the Worker during handling of
    * the Event
    */
-  jobs?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  jobs?: { [key: string]: Job }
 }
 
 /**
@@ -189,7 +189,7 @@ export interface WorkerSpec {
    * would like to embed configuration (e.g. brigade.json) or scripts (e.g.
    * brigade.js) directly within the WorkerSpec.
    */
-  defaultConfigFiles?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  defaultConfigFiles?: { [key: string]: string }
 }
 
 /**


### PR DESCRIPTION
In the course of initial development, the TS maps (e.g. `Map<K,V>`) were shunned because they don't serialize cleanly as JSON. For instance, a map containing key `foo` with value `bar` ends up looking something (roughly) like this: `{"type": "Map", "value": {"foo": "bar"}}`.

That caused numerous problems since the canonical representation of that in JSON would simply be `{"foo": "bar"}`-- which is what the server would expect in such cases.

The expedient solution to this was to use plain objects instead of maps. Type checking (the main benefit of using TypeScript) was thrown out the window and several instances of `Map<K,V>` were replaced with (evil and unsafe) `any`.

This evening, after conferring with a colleague more experienced with TypeScript, I have learned that the type `{ [key: string]: T }` will give me map-like semantics and the type checking we desire while still behaving like a normal object at runtime.

I have verified that objects of this type serialize as expected.

We should not merge this until after #2 is merged since that PR will wrangle CI into place and ideally we do not merge anything further until we have the benefit of those validations.