### PR TITLE
Update image pull policy to use the enum

### DIFF
--- a/src/core/containers.ts
+++ b/src/core/containers.ts
@@ -29,7 +29,7 @@ export interface ContainerSpec {
    * specifies whether a container host already having the specified OCI image
    * should attempt to re-pull that image prior to launching a new container
    */
-  imagePullPolicy?: string
+  imagePullPolicy?: ImagePullPolicy
   /**
    * Specifies the command to be executed by the OCI container. This can be used
    * to optionally override the default command specified by the OCI image


### PR DESCRIPTION
This commit updates the image pull policy in the container spec to use
ImagePullPolicy enum instead of a string.
